### PR TITLE
Add support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "livewire/flux": "^1.0|^2.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/view": "^10.0|^11.0|^12.0|^13.0",
-        "symfony/console": "^6.0|^7.0",
+        "symfony/console": "^6.0|^7.0|^8.0",
         "laravel/prompts": "^0.1|^0.2|^0.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,15 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "livewire/flux": "^1.0|^2.0",
-        "illuminate/console": "^10.0|^11.0|^12.0",
-        "illuminate/view": "^10.0|^11.0|^12.0",
+        "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/view": "^10.0|^11.0|^12.0|^13.0",
         "symfony/console": "^6.0|^7.0",
         "laravel/prompts": "^0.1|^0.2|^0.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0",
+        "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "mockery/mockery": "^1.6|^2.0",
         "orchestra/testbench": "^9.5|^10.0"
     },


### PR DESCRIPTION
This is just a quick PR that updates the package to support Laravel 13. Full disclosure is that it hasn't been thoroughly tested, just locally with the Laravel Livewire starter kit.